### PR TITLE
Feat/#1/review get

### DIFF
--- a/src/main/java/project/mapjiri/domain/restaurant/model/Restaurant.java
+++ b/src/main/java/project/mapjiri/domain/restaurant/model/Restaurant.java
@@ -35,7 +35,7 @@ public class Restaurant {
     private String restaurantNumber;
 
     @Column(nullable = false)
-    private ReviewTag reviewTag;
+    private ReviewTag topReviewTag;
 
     @Column(nullable = false)
     private Double restaurantLongitude;
@@ -56,7 +56,7 @@ public class Restaurant {
         this.restaurantOldPlace = restaurantOldPlace;
         this.restaurantNewPlace = restaurantNewPlace;
         this.restaurantNumber = restaurantNumber;
-        this.reviewTag = reviewTag;
+        this.topReviewTag = reviewTag;
         this.restaurantLongitude = restaurantLongitude;
         this.restaurantLatitude = restaurantLatitude;
     }

--- a/src/main/java/project/mapjiri/domain/restaurant/model/Restaurant.java
+++ b/src/main/java/project/mapjiri/domain/restaurant/model/Restaurant.java
@@ -2,8 +2,10 @@ package project.mapjiri.domain.restaurant.model;
 
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import project.mapjiri.domain.menu.model.Menu;
 import project.mapjiri.domain.place.model.Place;
 import project.mapjiri.domain.review.model.ReviewTag;
@@ -48,4 +50,14 @@ public class Restaurant {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id")
     private Place place;
+
+    public Restaurant(String restaurantName, String restaurantOldPlace, String restaurantNewPlace, String restaurantNumber, ReviewTag reviewTag, Double restaurantLongitude, Double restaurantLatitude) {
+        this.restaurantName = restaurantName;
+        this.restaurantOldPlace = restaurantOldPlace;
+        this.restaurantNewPlace = restaurantNewPlace;
+        this.restaurantNumber = restaurantNumber;
+        this.reviewTag = reviewTag;
+        this.restaurantLongitude = restaurantLongitude;
+        this.restaurantLatitude = restaurantLatitude;
+    }
 }

--- a/src/main/java/project/mapjiri/domain/restaurant/model/Restaurant.java
+++ b/src/main/java/project/mapjiri/domain/restaurant/model/Restaurant.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.mapjiri.domain.menu.model.Menu;
 import project.mapjiri.domain.place.model.Place;
+import project.mapjiri.domain.review.model.ReviewTag;
 
 
 import static jakarta.persistence.GenerationType.IDENTITY;

--- a/src/main/java/project/mapjiri/domain/restaurant/model/RestaurantRepository.java
+++ b/src/main/java/project/mapjiri/domain/restaurant/model/RestaurantRepository.java
@@ -1,0 +1,6 @@
+package project.mapjiri.domain.restaurant.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/src/main/java/project/mapjiri/domain/restaurant/model/ReviewTag.java
+++ b/src/main/java/project/mapjiri/domain/restaurant/model/ReviewTag.java
@@ -1,4 +1,0 @@
-package project.mapjiri.domain.restaurant.model;
-
-public enum ReviewTag {
-}

--- a/src/main/java/project/mapjiri/domain/review/controller/ReviewController.java
+++ b/src/main/java/project/mapjiri/domain/review/controller/ReviewController.java
@@ -1,0 +1,25 @@
+package project.mapjiri.domain.review.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import project.mapjiri.domain.review.service.ReviewService;
+import project.mapjiri.global.dto.ResponseDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/review")
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    @GetMapping("/restaurant")
+    public ResponseDto<?> getReviewsByRestaurant(@RequestParam(name = "restaurantId") Long id
+            , @RequestParam(defaultValue = "ASD", required = false) String sort
+            , @RequestParam(defaultValue = "1", required = false) int pageNumber) {
+        pageNumber = pageNumber <= 0 ? 0 : pageNumber - 1;
+
+        return ResponseDto.of(reviewService.getReviewsByRestaurant(id, sort, pageNumber), "리뷰 목록 조회 성공");
+    }
+}

--- a/src/main/java/project/mapjiri/domain/review/dto/ReviewListResponse.java
+++ b/src/main/java/project/mapjiri/domain/review/dto/ReviewListResponse.java
@@ -1,0 +1,24 @@
+package project.mapjiri.domain.review.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewListResponse {
+
+    private double averageScore;
+    private List<ReviewResponse> responseList;
+
+    private ReviewListResponse(double averageScore, List<ReviewResponse> responseList) {
+        this.responseList = responseList;
+        this.averageScore = averageScore;
+    }
+
+    public static ReviewListResponse of(double totalScore, List<ReviewResponse> responseList) {
+        return new ReviewListResponse(totalScore, responseList);
+    }
+}

--- a/src/main/java/project/mapjiri/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/project/mapjiri/domain/review/dto/ReviewResponse.java
@@ -1,0 +1,28 @@
+package project.mapjiri.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.mapjiri.domain.review.model.Review;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class ReviewResponse {
+    private String content;
+    private int score;
+    private LocalDate date;
+    private String imageUrl;
+
+    private ReviewResponse(String content, int score, LocalDate date, String imageUrl) {
+        this.content = content;
+        this.score = score;
+        this.date = date;
+        this.imageUrl = imageUrl;
+    }
+
+    public static ReviewResponse from(Review review) {
+        return new ReviewResponse(review.getReviewContent(), review.getReviewPoint(), review.getDate(), review.getReviewImageUrl());
+    }
+}

--- a/src/main/java/project/mapjiri/domain/review/model/Review.java
+++ b/src/main/java/project/mapjiri/domain/review/model/Review.java
@@ -34,4 +34,15 @@ public class Review {
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
+    private Review(String reviewContent, int reviewPoint, LocalDate date, String reviewImageUrl, Restaurant restaurant) {
+        this.reviewContent = reviewContent;
+        this.reviewPoint = reviewPoint;
+        this.date = date;
+        this.reviewImageUrl = reviewImageUrl;
+        this.restaurant = restaurant;
+    }
+
+    public static Review of(String reviewContent, int reviewPoint, LocalDate date, String reviewImageUrl, Restaurant restaurant) {
+        return new Review(reviewContent, reviewPoint, date, reviewImageUrl, restaurant);
+    }
 }

--- a/src/main/java/project/mapjiri/domain/review/model/ReviewSort.java
+++ b/src/main/java/project/mapjiri/domain/review/model/ReviewSort.java
@@ -1,0 +1,29 @@
+package project.mapjiri.domain.review.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewSort {
+    LATEST("최신순", "date", Sort.Direction.DESC),
+    OLDEST("오래된순", "date", Sort.Direction.ASC),
+    HIGH_SCORE("별점높은순", "reviewPoint", Sort.Direction.DESC),
+    LOW_SCORE("별점낮은순", "reviewPoint", Sort.Direction.ASC);
+
+    private final String description;
+    private final String field;  // JPA에서 정렬할 필드명
+    private final Sort.Direction direction;  // 정렬 방식
+
+
+    // 문자열을 Enum으로 변환
+    public static ReviewSort fromString(String sort) {
+        return Arrays.stream(values())
+                .filter(s -> s.name().equalsIgnoreCase(sort))
+                .findFirst()
+                .orElse(LATEST); // 기본값: 최신순 정렬
+    }
+}

--- a/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
+++ b/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -30,18 +31,17 @@ public enum ReviewTag {
                 .orElse(UNKNOWN); // 기본값: 최신순 정렬
     }
 
-    public static ReviewTag findMostFrequentTag(String[] reviewTags) {
+    public static ReviewTag findMostFrequentTag(List<ReviewTag> reviewTags) {
         Map<ReviewTag, Integer> tagCountMap = countTagFrom(reviewTags);
 
         return getTopReviewTag(tagCountMap);
     }
 
-    private static Map<ReviewTag, Integer> countTagFrom(String[] reviewTags) {
+    private static Map<ReviewTag, Integer> countTagFrom(List<ReviewTag> reviewTags) {
         Map<ReviewTag, Integer> tagCountMap = new HashMap<>();
 
-        for (String reviewTag : reviewTags) {
-            ReviewTag tag = ReviewTag.fromString(reviewTag);
-            tagCountMap.put(tag, tagCountMap.getOrDefault(tag, 0) + 1);
+        for (ReviewTag reviewTag : reviewTags) {
+            tagCountMap.put(reviewTag, tagCountMap.getOrDefault(reviewTag, 0) + 1);
         }
         return tagCountMap;
     }

--- a/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
+++ b/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
@@ -1,0 +1,4 @@
+package project.mapjiri.domain.review.model;
+
+public enum ReviewTag {
+}

--- a/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
+++ b/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
@@ -1,4 +1,5 @@
 package project.mapjiri.domain.review.model;
 
 public enum ReviewTag {
+    GO
 }

--- a/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
+++ b/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
@@ -1,5 +1,27 @@
 package project.mapjiri.domain.review.model;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
 public enum ReviewTag {
-    GO
+    TASTE("맛"),
+    VALUE_FOR_MONEY("가성비"),
+    FRIENDLY("친절"),
+    AMBIENCE("분위기"),
+    PARKING("주차"),
+    UNKNOWN("알수없음")
+    ;
+
+    private final String description;
+
+    public static ReviewTag fromString(String reviewTag) {
+        return Arrays.stream(values())
+                .filter(s -> s.description.equals(reviewTag))
+                .findFirst()
+                .orElse(UNKNOWN); // 기본값: 최신순 정렬
+    }
 }

--- a/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
+++ b/src/main/java/project/mapjiri/domain/review/model/ReviewTag.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 @Getter
 @RequiredArgsConstructor
@@ -13,15 +15,47 @@ public enum ReviewTag {
     FRIENDLY("친절"),
     AMBIENCE("분위기"),
     PARKING("주차"),
-    UNKNOWN("알수없음")
+    UNKNOWN("알수없음"),
+    NO_TAG("없음"),
     ;
 
     private final String description;
 
+    private static final int MIN_COUNT_THRESHOLD = 20;
+
     public static ReviewTag fromString(String reviewTag) {
         return Arrays.stream(values())
-                .filter(s -> s.description.equals(reviewTag))
+                .filter(tag -> tag.description.equals(reviewTag))
                 .findFirst()
                 .orElse(UNKNOWN); // 기본값: 최신순 정렬
+    }
+
+    public static ReviewTag findMostFrequentTag(String[] reviewTags) {
+        Map<ReviewTag, Integer> tagCountMap = countTagFrom(reviewTags);
+
+        return getTopReviewTag(tagCountMap);
+    }
+
+    private static Map<ReviewTag, Integer> countTagFrom(String[] reviewTags) {
+        Map<ReviewTag, Integer> tagCountMap = new HashMap<>();
+
+        for (String reviewTag : reviewTags) {
+            ReviewTag tag = ReviewTag.fromString(reviewTag);
+            tagCountMap.put(tag, tagCountMap.getOrDefault(tag, 0) + 1);
+        }
+        return tagCountMap;
+    }
+
+    private static ReviewTag getTopReviewTag(Map<ReviewTag, Integer> tagCountMap) {
+        ReviewTag mostFrequentTag = ReviewTag.UNKNOWN;
+        int maxCount = 0;
+        for (Map.Entry<ReviewTag, Integer> entry : tagCountMap.entrySet()) {
+            if (entry.getValue() > maxCount) {
+                maxCount = entry.getValue();
+                mostFrequentTag = entry.getKey();
+            }
+        }
+
+        return MIN_COUNT_THRESHOLD > maxCount ? NO_TAG : mostFrequentTag;
     }
 }

--- a/src/main/java/project/mapjiri/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/project/mapjiri/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,18 @@
+package project.mapjiri.domain.review.repository;
+
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import project.mapjiri.domain.review.model.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    @Query("SELECT r FROM Review r WHERE r.restaurant.restaurantId = :restaurantId")
+    Page<Review> findReviewsByRestaurantId(@Param(value = "restaurantId") Long restaurantId, Pageable pageable);
+
+    @Query("SELECT AVG(r.reviewPoint) FROM Review r WHERE r.restaurant.restaurantId = :restaurantId")
+    Double findAverageReviewPointByRestaurantId(@Param(value = "restaurantId") Long restaurantId);
+
+
+}

--- a/src/main/java/project/mapjiri/domain/review/service/ReviewService.java
+++ b/src/main/java/project/mapjiri/domain/review/service/ReviewService.java
@@ -1,0 +1,8 @@
+package project.mapjiri.domain.review.service;
+
+import project.mapjiri.domain.review.dto.ReviewListResponse;
+
+public interface ReviewService {
+
+    ReviewListResponse getReviewsByRestaurant(Long id, String sort, int pageNumber);
+}

--- a/src/main/java/project/mapjiri/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/project/mapjiri/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,40 @@
+package project.mapjiri.domain.review.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.mapjiri.domain.review.dto.ReviewListResponse;
+import project.mapjiri.domain.review.dto.ReviewResponse;
+import project.mapjiri.domain.review.model.Review;
+import project.mapjiri.domain.review.model.ReviewSort;
+import project.mapjiri.domain.review.repository.ReviewRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewServiceImpl implements ReviewService {
+    private final ReviewRepository reviewRepository;
+
+    private static final int REVIEWS_PER_PAGE = 15;
+
+    @Override
+    public ReviewListResponse getReviewsByRestaurant(Long id, String sort, int pageNumber) {
+        ReviewSort reviewSort = ReviewSort.fromString(sort);
+        PageRequest pageRequest = PageRequest.of(
+                pageNumber, REVIEWS_PER_PAGE,
+                Sort.by(reviewSort.getDirection(), reviewSort.getField()));
+
+        Page<Review> page = reviewRepository.findReviewsByRestaurantId(id, pageRequest);
+        Double averageReviewScore = reviewRepository.findAverageReviewPointByRestaurantId(id);
+
+        return ReviewListResponse.of(
+                averageReviewScore,
+                page.stream().map(ReviewResponse::from)
+                        .toList());
+    }
+
+}

--- a/src/test/java/project/mapjiri/domain/review/model/ReviewTagTest.java
+++ b/src/test/java/project/mapjiri/domain/review/model/ReviewTagTest.java
@@ -1,45 +1,71 @@
 package project.mapjiri.domain.review.model;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static project.mapjiri.domain.review.model.ReviewTag.*;
+
 class ReviewTagTest {
+
+    @DisplayName("주어진 문자열을 통해 ReviewTag 을 반환한다.")
+    @Test
+    void fromString_1() {
+        // given
+        String string = "맛";
+        // when
+        ReviewTag result = ReviewTag.fromString(string);
+        // then
+        assertThat(result).isEqualTo(TASTE);
+    }
+
+    @DisplayName("주어진 문자열이 양식에 없다면 ReviewTag UNKNOWN 을 반환한다.")
+    @Test
+    void fromString_2() {
+        // given
+        String string = "안녕하십니까!";
+        // when
+        ReviewTag result = ReviewTag.fromString(string);
+        // then
+        assertThat(result).isEqualTo(UNKNOWN);
+    }
 
 
     @DisplayName("제공된 리뷰 항목 중 최다 리뷰 항목을 제공한다.")
     @Test
     void findMostFrequentTag_1() {
         // given
-        String[] inputReviewTags = {
-                "맛", "맛", "맛", "맛", "맛",
-                "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절",
-                "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절",
-                "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절",
-                "분위기", "분위기", "분위기", "분위기", "분위기", "분위기", "분위기",
-                "주차", "주차", "주차", "주차", "주차", "주차", "주차"
-        };
+        List<ReviewTag> inputReviewTags = List.of(
+                TASTE, TASTE, TASTE, TASTE, TASTE,
+                FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY,
+                FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY,
+                FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY,
+                AMBIENCE, AMBIENCE, AMBIENCE, AMBIENCE, AMBIENCE, AMBIENCE, AMBIENCE,
+                PARKING, PARKING, PARKING, PARKING, PARKING, PARKING, PARKING
+        );
         // when
-        ReviewTag mostFrequentTag = ReviewTag.findMostFrequentTag(inputReviewTags);
+        ReviewTag mostFrequentTag = findMostFrequentTag(inputReviewTags);
 
         // then
-        Assertions.assertThat(mostFrequentTag).isEqualTo(ReviewTag.FRIENDLY);
+        assertThat(mostFrequentTag).isEqualTo(FRIENDLY);
     }
 
     @DisplayName("리뷰 태크 최소 임계값에 도달하지 않는다면 최다 태그 리뷰를 제공하지 않는다.")
     @Test
     void findMostFrequentTag_2() {
         // given
-        String[] inputReviewTags = {
-                "맛", "맛", "맛", "맛", "맛",
-                "분위기", "분위기", "분위기", "분위기", "분위기", "분위기", "분위기",
-                "주차", "주차", "주차", "주차", "주차", "주차", "주차"
-        };
+        List<ReviewTag> inputReviewTags = List.of(
+                TASTE, TASTE, TASTE, TASTE, TASTE,
+                FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY, FRIENDLY,
+                PARKING, PARKING, PARKING, PARKING, PARKING, PARKING
+        );
         // when
-        ReviewTag mostFrequentTag = ReviewTag.findMostFrequentTag(inputReviewTags);
+        ReviewTag mostFrequentTag = findMostFrequentTag(inputReviewTags);
 
         // then
-        Assertions.assertThat(mostFrequentTag).isEqualTo(ReviewTag.NO_TAG);
+        assertThat(mostFrequentTag).isEqualTo(NO_TAG);
     }
 
 }

--- a/src/test/java/project/mapjiri/domain/review/model/ReviewTagTest.java
+++ b/src/test/java/project/mapjiri/domain/review/model/ReviewTagTest.java
@@ -1,0 +1,45 @@
+package project.mapjiri.domain.review.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReviewTagTest {
+
+
+    @DisplayName("제공된 리뷰 항목 중 최다 리뷰 항목을 제공한다.")
+    @Test
+    void findMostFrequentTag_1() {
+        // given
+        String[] inputReviewTags = {
+                "맛", "맛", "맛", "맛", "맛",
+                "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절",
+                "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절",
+                "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절", "친절",
+                "분위기", "분위기", "분위기", "분위기", "분위기", "분위기", "분위기",
+                "주차", "주차", "주차", "주차", "주차", "주차", "주차"
+        };
+        // when
+        ReviewTag mostFrequentTag = ReviewTag.findMostFrequentTag(inputReviewTags);
+
+        // then
+        Assertions.assertThat(mostFrequentTag).isEqualTo(ReviewTag.FRIENDLY);
+    }
+
+    @DisplayName("리뷰 태크 최소 임계값에 도달하지 않는다면 최다 태그 리뷰를 제공하지 않는다.")
+    @Test
+    void findMostFrequentTag_2() {
+        // given
+        String[] inputReviewTags = {
+                "맛", "맛", "맛", "맛", "맛",
+                "분위기", "분위기", "분위기", "분위기", "분위기", "분위기", "분위기",
+                "주차", "주차", "주차", "주차", "주차", "주차", "주차"
+        };
+        // when
+        ReviewTag mostFrequentTag = ReviewTag.findMostFrequentTag(inputReviewTags);
+
+        // then
+        Assertions.assertThat(mostFrequentTag).isEqualTo(ReviewTag.NO_TAG);
+    }
+
+}

--- a/src/test/java/project/mapjiri/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/project/mapjiri/domain/review/service/ReviewServiceImplTest.java
@@ -1,0 +1,142 @@
+package project.mapjiri.domain.review.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import project.mapjiri.domain.restaurant.model.Restaurant;
+import project.mapjiri.domain.restaurant.model.RestaurantRepository;
+import project.mapjiri.domain.review.dto.ReviewListResponse;
+import project.mapjiri.domain.review.dto.ReviewResponse;
+import project.mapjiri.domain.review.model.Review;
+import project.mapjiri.domain.review.model.ReviewTag;
+import project.mapjiri.domain.review.repository.ReviewRepository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@SpringBootTest
+class ReviewServiceImplTest {
+    @Autowired
+    ReviewService reviewService;
+    @Autowired
+    ReviewRepository reviewRepository;
+    @Autowired
+    RestaurantRepository restaurantRepository;
+
+    @DisplayName("최신순, 오래된순 등 여러 기준 별 리뷰 페이징 조회 시나리오")
+    @TestFactory
+    Collection<DynamicTest> getReviewsByRestaurant() {
+        // given
+        Restaurant restaurant1 = new Restaurant("식당1", "구주소1", "신주소1", "번호1", ReviewTag.GO, 0.1, 0.1);
+        Restaurant restaurant2 = new Restaurant("식당2", "구주소2", "신주소2", "번호2", ReviewTag.GO, 0.1, 0.2);
+        restaurantRepository.saveAllAndFlush(List.of(restaurant1, restaurant2));
+
+        List<Review> reviews = new ArrayList<>();
+        for (int per = 1; per <= 20; per++) {
+            Review review = Review.of("리뷰" + per, 4,
+                    LocalDate.of(2024, 3, per), "null", restaurant1);
+            reviews.add(review);
+        }
+        for (int per = 21; per <= 31; per++) {
+            Review review = Review.of("리뷰" + per, 3,
+                    LocalDate.of(2024, 3, per), "null", restaurant1);
+            reviews.add(review);
+        }
+        reviewRepository.saveAllAndFlush(reviews);
+
+        // when & then
+        return List.of(
+                DynamicTest.dynamicTest("오래된순으로 리뷰 목록 페이지를 조회합니다.", () -> {
+
+                    //when
+                    ReviewListResponse result = reviewService.getReviewsByRestaurant(restaurant1.getRestaurantId(), "oldest", 0);
+                    // then
+                    List<ReviewResponse> responseList = result.getResponseList();
+                    assertThat(responseList)
+                            .extracting("date")
+                            .containsExactly(
+                                    LocalDate.of(2024, 3, 1),
+                                    LocalDate.of(2024, 3, 2),
+                                    LocalDate.of(2024, 3, 3),
+                                    LocalDate.of(2024, 3, 4),
+                                    LocalDate.of(2024, 3, 5),
+                                    LocalDate.of(2024, 3, 6),
+                                    LocalDate.of(2024, 3, 7),
+                                    LocalDate.of(2024, 3, 8),
+                                    LocalDate.of(2024, 3, 9),
+                                    LocalDate.of(2024, 3, 10),
+                                    LocalDate.of(2024, 3, 11),
+                                    LocalDate.of(2024, 3, 12),
+                                    LocalDate.of(2024, 3, 13),
+                                    LocalDate.of(2024, 3, 14),
+                                    LocalDate.of(2024, 3, 15)
+                            );
+                }),
+                DynamicTest.dynamicTest("최신순으로 리뷰 목록 페이지를 조회합니다.", () -> {
+
+                    //when
+                    ReviewListResponse result = reviewService.getReviewsByRestaurant(restaurant1.getRestaurantId(), "lastest", 0);
+                    // then
+                    List<ReviewResponse> responseList = result.getResponseList();
+                    assertThat(responseList)
+                            .extracting("date")
+                            .containsExactly(
+                                    LocalDate.of(2024, 3, 31),
+                                    LocalDate.of(2024, 3, 30),
+                                    LocalDate.of(2024, 3, 29),
+                                    LocalDate.of(2024, 3, 28),
+                                    LocalDate.of(2024, 3, 27),
+                                    LocalDate.of(2024, 3, 26),
+                                    LocalDate.of(2024, 3, 25),
+                                    LocalDate.of(2024, 3, 24),
+                                    LocalDate.of(2024, 3, 23),
+                                    LocalDate.of(2024, 3, 22),
+                                    LocalDate.of(2024, 3, 21),
+                                    LocalDate.of(2024, 3, 20),
+                                    LocalDate.of(2024, 3, 19),
+                                    LocalDate.of(2024, 3, 18),
+                                    LocalDate.of(2024, 3, 17)
+                            );
+                }),
+                DynamicTest.dynamicTest("별점 높은 순으로 리뷰 목록 페이지를 조회합니다.", () -> {
+
+                    //when
+                    ReviewListResponse result = reviewService.getReviewsByRestaurant(restaurant1.getRestaurantId(), "high_score", 1);
+                    // then
+
+                    List<ReviewResponse> responseList = result.getResponseList();
+                    assertThat(responseList)
+                            .extracting("score", "date")
+                            .containsExactly(
+                                    tuple(4, LocalDate.of(2024, 3, 16)),
+                                    tuple(4, LocalDate.of(2024, 3, 17)),
+                                    tuple(4, LocalDate.of(2024, 3, 18)),
+                                    tuple(4, LocalDate.of(2024, 3, 19)),
+                                    tuple(4, LocalDate.of(2024, 3, 20)),
+                                    tuple(3, LocalDate.of(2024, 3, 21)),
+                                    tuple(3, LocalDate.of(2024, 3, 22)),
+                                    tuple(3, LocalDate.of(2024, 3, 23)),
+                                    tuple(3, LocalDate.of(2024, 3, 24)),
+                                    tuple(3, LocalDate.of(2024, 3, 25)),
+                                    tuple(3, LocalDate.of(2024, 3, 26)),
+                                    tuple(3, LocalDate.of(2024, 3, 27)),
+                                    tuple(3, LocalDate.of(2024, 3, 28)),
+                                    tuple(3, LocalDate.of(2024, 3, 29)),
+                                    tuple(3, LocalDate.of(2024, 3, 30))
+                            );
+                })
+
+        );
+
+
+    }
+
+
+}

--- a/src/test/java/project/mapjiri/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/project/mapjiri/domain/review/service/ReviewServiceImplTest.java
@@ -34,9 +34,8 @@ class ReviewServiceImplTest {
     @TestFactory
     Collection<DynamicTest> getReviewsByRestaurant() {
         // given
-        Restaurant restaurant1 = new Restaurant("식당1", "구주소1", "신주소1", "번호1", ReviewTag.GO, 0.1, 0.1);
-        Restaurant restaurant2 = new Restaurant("식당2", "구주소2", "신주소2", "번호2", ReviewTag.GO, 0.1, 0.2);
-        restaurantRepository.saveAllAndFlush(List.of(restaurant1, restaurant2));
+        Restaurant restaurant1 = new Restaurant("식당1", "구주소1", "신주소1", "번호1", ReviewTag.TASTE, 0.1, 0.1);
+        restaurantRepository.saveAndFlush(restaurant1);
 
         List<Review> reviews = new ArrayList<>();
         for (int per = 1; per <= 20; per++) {


### PR DESCRIPTION
## 📋 이슈 번호
    close #1 
## 🛠 구현 사항
  리뷰 조회 기능 구현
  - 리뷰 목록 조회 API : 가게 리뷰 목록을 조회합니다.
  - 최다 태그 제공 기능 : 가게 리뷰 항목에서 최다 태크를 제공합니다.
## 📚 기타

 최다 태그 제공 기능 : 크롤링 정보를 토대로 가게 정보를 저장할 때 가게명과 최다 태그를 같이 저장한다고 생각하여  API 로 만들지 않음