### PR TITLE
근처 식당 정보에 전화번호 추가

### DIFF
--- a/src/main/java/project/mapjiri/domain/restaurant/dto/NearbyRestaurantsResponseDto.java
+++ b/src/main/java/project/mapjiri/domain/restaurant/dto/NearbyRestaurantsResponseDto.java
@@ -37,6 +37,7 @@ public class NearbyRestaurantsResponseDto {
         private final String restaurantName;
         private final String address;
         private final String roadAddressName;
+        private final String phoneNumber;
         private final Double longitude;
         private final Double latitude;
 
@@ -44,6 +45,7 @@ public class NearbyRestaurantsResponseDto {
             this.restaurantName = documents.getRestaurantName();
             this.address = documents.getAddress();
             this.roadAddressName = documents.getRoadAddressName();
+            this.phoneNumber = documents.getPhoneNumber();
             this.longitude = documents.getLongitude();
             this.latitude = documents.getLatitude();
         }

--- a/src/main/java/project/mapjiri/global/client/dto/KakaoNearbyRestaurantResponseDto.java
+++ b/src/main/java/project/mapjiri/global/client/dto/KakaoNearbyRestaurantResponseDto.java
@@ -37,6 +37,9 @@ public class KakaoNearbyRestaurantResponseDto {
         @JsonProperty("road_address_name")
         private String roadAddressName;
 
+        @JsonProperty("phone")
+        private String phoneNumber;
+
         @JsonProperty("x")
         private Double longitude;
 

--- a/src/test/java/project/mapjiri/global/client/KakaoMapClientTest.java
+++ b/src/test/java/project/mapjiri/global/client/KakaoMapClientTest.java
@@ -558,11 +558,13 @@ class KakaoMapClientTest {
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getRestaurantName()).isEqualTo("원조뒷고기"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getAddress()).isEqualTo("대전 유성구 장대동 280-10"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getRoadAddressName()).isEqualTo("대전 유성구 장대로 41"),
+                () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getPhoneNumber()).isEqualTo("042-822-2667"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getLongitude()).isEqualTo(127.336150709515),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getLatitude()).isEqualTo( 36.3586773933956),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(29).getRestaurantName()).isEqualTo("한밭추어탕"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(29).getAddress()).isEqualTo("대전 유성구 장대동 279-1"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(29).getRoadAddressName()).isEqualTo("대전 유성구 유성대로740번길 38"),
+                () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(29).getPhoneNumber()).isEqualTo("042-477-3651"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(29).getLongitude()).isEqualTo(127.33544260170268),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(29).getLatitude()).isEqualTo(36.35931200826078)
         );
@@ -865,11 +867,13 @@ class KakaoMapClientTest {
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getRestaurantName()).isEqualTo("온전히소바"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getAddress()).isEqualTo("대전 유성구 장대동 281-25"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getRoadAddressName()).isEqualTo("대전 유성구 문화원로6번길 48-1"),
+                () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getPhoneNumber()).isEqualTo("010-2179-0986"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getLongitude()).isEqualTo(127.33664792211643),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(0).getLatitude()).isEqualTo( 36.35978173518269),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(16).getRestaurantName()).isEqualTo("이것이국밥이다 대전유성점"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(16).getAddress()).isEqualTo("대전 유성구 장대동 270-5"),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(16).getRoadAddressName()).isEqualTo("대전 유성구 유성대로 757-39"),
+                () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(16).getPhoneNumber()).isEqualTo(""),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(16).getLongitude()).isEqualTo(127.334242673825),
                 () -> assertThat(nearbyRestaurantsResponseDto.getRestaurantLists().get(16).getLatitude()).isEqualTo(36.360621173302)
         );


### PR DESCRIPTION
## 📋 이슈 번호

#2 

🛠 구현 사항

근처 음식점 조회시 전화번호도 함께 응답하도록 수정했습니다.

```java
// 응답
{
    "data": {
        "totalCount": 4,
        "restaurantLists": [
            {
                "restaurantName": "마시내탕수육",
                "address": "대전 유성구 장대동 355-15",
                "roadAddressName": "대전 유성구 문화원로14번길 14",
                "phoneNumber": "042-823-9981",
                "longitude": 127.33745495903123,
                "latitude": 36.3609014211769
            },
            {
                "restaurantName": "보배반점 구암역점",
                "address": "대전 유성구 장대동 267-5",
                "roadAddressName": "대전 유성구 유성대로 721",
                "phoneNumber": "042-825-9073",
                "longitude": 127.332051065171,
                "latitude": 36.3582580948661
            },
            {
                "restaurantName": "미술관",
                "address": "대전 유성구 장대동 368-18",
                "roadAddressName": "대전 유성구 문화원로6번길 71",
                "phoneNumber": "",
                "longitude": 127.337726186932,
                "latitude": 36.3589496114294
            },
            {
                "restaurantName": "하오치띵호와",
                "address": "대전 유성구 장대동 283-6",
                "roadAddressName": "대전 유성구 문화원로6번길 90",
                "phoneNumber": "042-826-1363",
                "longitude": 127.33772154935,
                "latitude": 36.3581340611659
            }
        ]
    },
    "msg": "근처 짜장면 가게 조회 성공"
}
```

📚 기타
전화번호가 없다면 "" 로 응답으로 두었습니다. "미등록", "없음" 같은 값을 원하시면 말씀해주세요 !