### PR TITLE
[Fix] User signIn 패스워드 비교 로직 수정

### DIFF
--- a/src/main/java/project/mapjiri/domain/user/service/UserService.java
+++ b/src/main/java/project/mapjiri/domain/user/service/UserService.java
@@ -55,11 +55,12 @@ public class UserService {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
 
-        String password = user.getPassword();
-        // 암호화된 비밀번호
-        String encodedPassword = passwordEncoder.encode(password);
+        // 사용자가 입력한 패스워드
+        String rawPassword = request.getPassword();
+        // 회원가입 할 때 입력한 패스워드 (암호화되어 있는 상태)
+        String storedPassword = user.getPassword();
 
-        if (!passwordEncoder.matches(password, encodedPassword)) {
+        if (!passwordEncoder.matches(rawPassword, storedPassword)) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 


### PR DESCRIPTION
### 이슈 번호
----
#38 

close #38 

### 구현한 내용
---
- [x] User signIn 패스워드 비교 로직 수정

### 참고 자료
---
```java
// 기존 코드
public SignInResponseDto signIn(SignInRequestDto request) {
        User user = userRepository.findByEmail(request.getEmail())
                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));

        String password = user.getPassword();
        String encodedPassword = passwordEncoder.encode(password);

        if (!passwordEncoder.matches(password, encodedPassword)) {
            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
        }
...
```
기존의 코드에서 잘못된 패스워드를 입력해도 로그인이 잘 되는 오류를 발견하였습니다

**비밀번호 암호화는 단방향 암호화**입니다.
`passwordEncoder.encode()`에 동일한 String을 입력하여도 항상 다른 암호화 결과를 생성하게 됩니다.

예를 들어서,
```java
String encoded1 = passwordEncoder.encode("Password123!");
String encoded2 = passwordEncoder.encode("Password123!");
System.out.println(encoded1.equals(encoded2));  // 항상 false 반환
```
이 경우에 똑같은 String의 값을 넣어도 결과 값이 다르기 때문에 직접 패스워드를 비교하면 항상 false를 나타내는 것입니다.

그래서 encode() 된 비밀번호를 비교하기 위해서는 `passwordEncoder.matches()`를 사용해야 합니다.

```java
    String rawPassword = request.getPassword(); // 사용자가 입력한 원본 비밀번호
    String storedPassword = user.getPassword(); // DB에 저장된 암호화된 비밀번호

    // 올바른 비밀번호 검증 방법
    if (!passwordEncoder.matches(rawPassword, storedPassword)) {
        throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
    }
```
사용자가 입력한 비밀번호와 회원가입 할 때 입력했던 암호화된 비밀번호를 matches()를 사용하여 비교하면 올바른 비밀번호 비교 로직이 완성됩니다.