### PR TITLE
[Fix] User 테스트 코드 수정

### DIFF
--- a/src/test/java/project/mapjiri/domain/user/service/UserServiceTest.java
+++ b/src/test/java/project/mapjiri/domain/user/service/UserServiceTest.java
@@ -109,7 +109,7 @@ public class UserServiceTest {
         assertEquals(signUpRequestDto.getEmail(), response.getEmail());
         assertEquals(signUpRequestDto.getUsername(), response.getUsername());
 
-        verify(passwordEncoder, times(2)).encode(signUpRequestDto.getPassword());
+        verify(passwordEncoder, times(1)).encode(signUpRequestDto.getPassword());
         verify(userRepository, times(1)).save(any(User.class));
     }
 

--- a/src/test/java/project/mapjiri/domain/user/service/UserServiceTest.java
+++ b/src/test/java/project/mapjiri/domain/user/service/UserServiceTest.java
@@ -16,6 +16,8 @@ import project.mapjiri.domain.user.dto.response.SignUpResponseDto;
 import project.mapjiri.domain.user.model.User;
 import project.mapjiri.domain.user.provider.JwtTokenProvider;
 import project.mapjiri.domain.user.repository.UserRepository;
+import project.mapjiri.global.exception.MyErrorCode;
+import project.mapjiri.global.exception.MyException;
 
 import java.util.Optional;
 
@@ -113,37 +115,49 @@ public class UserServiceTest {
         verify(userRepository, times(1)).save(any(User.class));
     }
 
-    @Test()
-    void 회원가인_이메일_중복_실패() {
+    @Test
+    void 회원가입_이메일_중복_실패() {
+        // 이메일이 이미 존재한다고 설정
         when(userRepository.existsByEmail(signUpRequestDto.getEmail())).thenReturn(true);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> userService.signUp(signUpRequestDto));
-        assertEquals("이미 존재하는 이메일입니다.", exception.getMessage());
+        // 예외가 발생하는지 검증 (IllegalArgumentException -> MyException으로 변경)
+        MyException exception = assertThrows(MyException.class, () -> userService.signUp(signUpRequestDto));
 
+        // 예외 코드와 메시지 검증
+        assertEquals(MyErrorCode.ALREADY_EMAIL, exception.getErrorCode());
+        assertEquals("이미 존재하는 이메일입니다.", exception.getErrorCode().getMessage());
+
+        // 이메일 중복 시, 인증 여부 및 저장 로직은 실행되지 않아야 함
         verify(redisService, never()).isMailVerified(anyString());
         verify(userRepository, never()).save(any(User.class));
     }
 
-    @Test()
+
+    @Test
     void 회원가입_이메일_인증_실패() {
         when(userRepository.existsByEmail(signUpRequestDto.getEmail())).thenReturn(false);
         when(redisService.isMailVerified(signUpRequestDto.getEmail())).thenReturn(false);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> userService.signUp(signUpRequestDto));
-        assertEquals("이메일 인증이 필요합니다.", exception.getMessage());
+        MyException exception = assertThrows(MyException.class, () -> userService.signUp(signUpRequestDto));
+
+        assertEquals(MyErrorCode.EMAIL_VERIFICATION_REQUIRED, exception.getErrorCode());
+        assertEquals("이메일 인증이 필요합니다.", exception.getErrorCode().getMessage());
 
         verify(userRepository, never()).existsByUsername(anyString());
         verify(userRepository, never()).save(any(User.class));
     }
 
-    @Test()
+
+    @Test
     void 회원가입_닉네임_중복_실패() {
         when(userRepository.existsByEmail(signUpRequestDto.getEmail())).thenReturn(false);
         when(redisService.isMailVerified(signUpRequestDto.getEmail())).thenReturn(true);
         when(userRepository.existsByUsername(signUpRequestDto.getUsername())).thenReturn(true);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> userService.signUp(signUpRequestDto));
-        assertEquals("이미 존재하는 닉네임입니다.", exception.getMessage());
+        MyException exception = assertThrows(MyException.class, () -> userService.signUp(signUpRequestDto));
+
+        assertEquals(MyErrorCode.DUPLICATE_USERNAME, exception.getErrorCode());
+        assertEquals("이미 존재하는 닉네임입니다.", exception.getErrorCode().getMessage());
 
         verify(userRepository, never()).save(any(User.class));
     }


### PR DESCRIPTION
### 이슈 번호
----
#47 

close #47 

### 구현한 내용
---
- [x] ErrorCode 수정
- [x] 회원가입_성공 로직 중 passwordEncoder.encode() 한 번만 실행되도록 수정

### 참고 자료
---
![스크린샷 2025-02-18 오후 2 16 10](https://github.com/user-attachments/assets/0b2e5589-c5f3-425e-9472-c059ede140ac)

